### PR TITLE
Fix language around open source claims of other wallets

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 				  <div class="feature-box wow animated flipInX" data-wow-delay="0.3s">
 		                       <img src="assets/img/github.png" style="width:128px"/>
 						<h2>Libre</h2>
-						<p>Find <b>the full</b> code <a href="https://github.com/walleth">on our github organisation</a>. We do not claim to be open source but only publish part of the source code like other wallets.</p>
+						<p>Find <b>the full</b> code <a href="https://github.com/walleth">on our github organisation</a>. Many other wallets claim to be open source, but only publish part of their source code.</p>
 					</div>
 				</div>
 


### PR DESCRIPTION
The previous wording was a bit ambiguous. It could be read as "Like other wallets, we claim to be open source but only publish part of our source code". This wording is more clear.